### PR TITLE
Fix - ImportError: cannot import name 'length_of_longest_substring' in solution.py

### DIFF
--- a/algorithms/sliding_window/lc_3_longest_substring_without_repeating_chars/solution.py
+++ b/algorithms/sliding_window/lc_3_longest_substring_without_repeating_chars/solution.py
@@ -28,10 +28,7 @@ and move the i (start) pointer to the right until the duplicate char is removed
 basically closing the window past the duplicate
 """
 
-
-def main():
-
-    def length_of_longest_substring(s: str) -> int:
+def length_of_longest_substring(s: str) -> int:
         if not s:
             return 0
         
@@ -55,15 +52,15 @@ def main():
             
         return max_count
 
-
+def main():
     assert length_of_longest_substring("dvdf") == 3
     assert length_of_longest_substring("aabbb") == 2
     assert length_of_longest_substring("a") == 1
     assert length_of_longest_substring(" ") == 1
     assert length_of_longest_substring("") == 0
     assert length_of_longest_substring("abcabcbb") == 3
-
     print("assertion tests passed!")
+
 
 if __name__ == "__main__":
     main()

--- a/tests/algos/test_sliding_window.py
+++ b/tests/algos/test_sliding_window.py
@@ -1,25 +1,5 @@
 import pytest
-# import unittest
-
-# from algorithms.sliding_window.lc_3_longest_substring_without_repeating_chars.solution import length_of_longest_substring
-
-def length_of_longest_substring(s: str) -> int:
-    if not s:
-        return 0
-    
-    unique = set()
-    max_count = 0
-    i = 0
-
-    for j in range(len(s)):
-        while s[j] in unique:
-            unique.remove(s[i])
-            i += 1
-        unique.add(s[j])
-        
-        max_count = max(max_count, len(unique))
-        
-    return max_count
+from algorithms.sliding_window.lc_3_longest_substring_without_repeating_chars.solution import length_of_longest_substring
 
 
 class TestSlidingWindow:
@@ -75,4 +55,3 @@ class TestSlidingWindow:
 
 if __name__ == "__main__":
     pytest.main()
-    # unittest.main()


### PR DESCRIPTION
## Description:
getting importError when running pytest.  

## Summary of Changes
- def length_of_longest_substring() is nested in main()  and therefore not at module level.  Removed this core function outside of main function to ensure that it could be imported by the test file.
- Ensured parent modules had __init__.py files.  Updated/ensured absolute import in test file was correct. 
- Cleaned up files by deleting commented code.

## Tests:
- [ ] cd to root and run pytest.  All tests ran and passed as expected.
- [ ] cd to lc_3_longest_substring_without_repeating_chars and run solution.py.  
